### PR TITLE
Bump version to 20260605.00

### DIFF
--- a/patches/fix-install-for-non-root.patch
+++ b/patches/fix-install-for-non-root.patch
@@ -1,0 +1,11 @@
+diff -Naur a/src/Makefile b/src/Makefile
+--- a/src/Makefile	2026-06-12 07:58:20
++++ b/src/Makefile	2026-06-12 07:59:24
+@@ -132,7 +132,4 @@
+ 	install -d $(DEST_PRESETDIR)
+ 	install -m 0644 -t $(DEST_PRESETDIR) $(TOPDIR)/90-google-compute-engine-oslogin.preset
+ endif
+-	# README file in google-users.d
+-	install -m 0640 -d $(DEST_GOOGLEUSERSDIR)
+-	install -m 0644 -T $(TOPDIR)/google-users-d-README $(DEST_GOOGLEUSERSDIR)/README
+ 

--- a/patches/series
+++ b/patches/series
@@ -1,0 +1,1 @@
+fix-install-for-non-root.patch

--- a/prepare_source
+++ b/prepare_source
@@ -1,5 +1,4 @@
-version_orig=20250624.00
-version_suffix=gl0
+version_orig=20260605.00
 
 # Clone upstream repository
 workdir="$(mktemp -d)"

--- a/prepare_source
+++ b/prepare_source
@@ -33,4 +33,6 @@ popd
 # Import modified upstream source distribution
 import_src "$workdir"
 
+apply_patches patches
+
 rm -rf "$workdir"


### PR DESCRIPTION
What this PR does / why we need it:
Update to the latest version and add a patch that removes the `/var/google-users.d/README` file from the installation.

The install step from the Makefile uses `0640` as rights for the folder s.t. our non-root user cannot access the folder to copy the README file there.

Creating the folder first with normal rights, copying the README, and then setting the folder's rights to `0640` does not work because then the following `dh_link` step fails with a permission error.

Hence, removing the README is the best option.

Which issue(s) this PR fixes:
Part of: https://github.com/gardenlinux/gardenlinux/issues/4879